### PR TITLE
feat: instrument all services with otel java agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ Thumbs.db
 
 # Docker
 docker-compose.override.yml
+infra/otel-agent/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ volumes:
 
 services:
 
+  # ── INFRAESTRUCTURA ──────────────────────────────────────────────────────
+
   tempo:
     image: grafana/tempo:2.6.1
     container_name: tempo
@@ -20,8 +22,8 @@ services:
       - ./infra/tempo.yml:/etc/tempo.yml
       - tempo-data:/var/tempo
     ports:
-      - "3200:3200"   # HTTP API — el agente consulta trazas acá
-      - "4317:4317"   # gRPC — recibe spans del open telemetry collector (OTel) Collector
+      - "3200:3200"
+      - "4317:4317"
     networks:
       - rca-net
 
@@ -61,11 +63,11 @@ services:
   otel-collector:
     image: otel/opentelemetry-collector-contrib:0.111.0
     container_name: otel-collector
-    command: [ "--config=/etc/otel-collector-config.yml" ]
+    command: ["--config=/etc/otel-collector-config.yml"]
     volumes:
       - ./infra/otel-collector-config.yml:/etc/otel-collector-config.yml
     ports:
-      - "4318:4318"   # HTTP — los servicios Kotlin mandan spans acá
+      - "4318:4318"
     depends_on:
       - tempo
       - prometheus
@@ -79,5 +81,124 @@ services:
       - "11434:11434"
     volumes:
       - ollama-data:/root/.ollama
+    networks:
+      - rca-net
+
+  # ── KAFKA ────────────────────────────────────────────────────────────────
+
+  kafka:
+    image: confluentinc/cp-kafka:7.7.0
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+      CLUSTER_ID: "MkU3OEVBNTcwNTJENDM2Qg"
+    networks:
+      - rca-net
+
+  # ── SERVICIOS KOTLIN ─────────────────────────────────────────────────────
+
+  order-service:
+    build:
+      context: .
+      dockerfile: services/order-service/Dockerfile
+    container_name: order-service
+    ports:
+      - "8081:8081"
+    environment:
+      - PORT=8081
+      - PAYMENT_SERVICE_URL=http://payment-service:8082
+      - INVENTORY_SERVICE_URL=http://inventory-service:8083
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+      - JAVA_TOOL_OPTIONS=-javaagent:/otel-agent/opentelemetry-javaagent.jar
+      - OTEL_SERVICE_NAME=order-service
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+      - OTEL_METRICS_EXPORTER=otlp
+      - OTEL_LOGS_EXPORTER=otlp
+    volumes:
+      - ./infra/otel-agent:/otel-agent:ro
+    depends_on:
+      - otel-collector
+      - kafka
+    networks:
+      - rca-net
+
+  payment-service:
+    build:
+      context: .
+      dockerfile: services/payment-service/Dockerfile
+    container_name: payment-service
+    ports:
+      - "8082:8082"
+    environment:
+      - PORT=8082
+      - INVENTORY_SERVICE_URL=http://inventory-service:8083
+      - JAVA_TOOL_OPTIONS=-javaagent:/otel-agent/opentelemetry-javaagent.jar
+      - OTEL_SERVICE_NAME=payment-service
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+      - OTEL_METRICS_EXPORTER=otlp
+      - OTEL_LOGS_EXPORTER=otlp
+    volumes:
+      - ./infra/otel-agent:/otel-agent:ro
+    depends_on:
+      - otel-collector
+      - inventory-service
+    networks:
+      - rca-net
+
+  inventory-service:
+    build:
+      context: .
+      dockerfile: services/inventory-service/Dockerfile
+    container_name: inventory-service
+    ports:
+      - "8083:8083"
+    environment:
+      - PORT=8083
+      - JAVA_TOOL_OPTIONS=-javaagent:/otel-agent/opentelemetry-javaagent.jar
+      - OTEL_SERVICE_NAME=inventory-service
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+      - OTEL_METRICS_EXPORTER=otlp
+      - OTEL_LOGS_EXPORTER=otlp
+    volumes:
+      - ./infra/otel-agent:/otel-agent:ro
+    depends_on:
+      - otel-collector
+    networks:
+      - rca-net
+
+  notification-service:
+    build:
+      context: .
+      dockerfile: services/notification-service/Dockerfile
+    container_name: notification-service
+    ports:
+      - "8084:8084"
+    environment:
+      - PORT=8084
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+      - JAVA_TOOL_OPTIONS=-javaagent:/otel-agent/opentelemetry-javaagent.jar
+      - OTEL_SERVICE_NAME=notification-service
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+      - OTEL_METRICS_EXPORTER=otlp
+      - OTEL_LOGS_EXPORTER=otlp
+    volumes:
+      - ./infra/otel-agent:/otel-agent:ro
+    depends_on:
+      - otel-collector
+      - kafka
     networks:
       - rca-net

--- a/scripts/download-otel-agent.sh
+++ b/scripts/download-otel-agent.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+mkdir -p infra/otel-agent
+JAR="infra/otel-agent/opentelemetry-javaagent.jar"
+if [ ! -f "$JAR" ]; then
+  echo "Descargando OTel Java Agent v2.9.0..."
+  curl -L -o "$JAR" \
+    https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.9.0/opentelemetry-javaagent.jar
+  echo "Listo → $JAR"
+else
+  echo "OTel agent ya existe → $JAR"
+fi

--- a/services/inventory-service/Dockerfile
+++ b/services/inventory-service/Dockerfile
@@ -1,0 +1,11 @@
+FROM eclipse-temurin:21-jdk-alpine AS builder
+WORKDIR /app
+COPY gradlew settings.gradle.kts build.gradle.kts ./
+COPY gradle ./gradle
+COPY services/inventory-service ./services/inventory-service
+RUN ./gradlew :services:inventory-service:bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+COPY --from=builder /app/services/inventory-service/build/libs/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/services/notification-service/Dockerfile
+++ b/services/notification-service/Dockerfile
@@ -1,0 +1,11 @@
+FROM eclipse-temurin:21-jdk-alpine AS builder
+WORKDIR /app
+COPY gradlew settings.gradle.kts build.gradle.kts ./
+COPY gradle ./gradle
+COPY services/notification-service ./services/notification-service
+RUN ./gradlew :services:notification-service:bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+COPY --from=builder /app/services/notification-service/build/libs/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/services/order-service/Dockerfile
+++ b/services/order-service/Dockerfile
@@ -1,0 +1,11 @@
+FROM eclipse-temurin:21-jdk-alpine AS builder
+WORKDIR /app
+COPY gradlew settings.gradle.kts build.gradle.kts ./
+COPY gradle ./gradle
+COPY services/order-service ./services/order-service
+RUN ./gradlew :services:order-service:bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+COPY --from=builder /app/services/order-service/build/libs/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/services/payment-service/Dockerfile
+++ b/services/payment-service/Dockerfile
@@ -1,0 +1,11 @@
+FROM eclipse-temurin:21-jdk-alpine AS builder
+WORKDIR /app
+COPY gradlew settings.gradle.kts build.gradle.kts ./
+COPY gradle ./gradle
+COPY services/payment-service ./services/payment-service
+RUN ./gradlew :services:payment-service:bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+COPY --from=builder /app/services/payment-service/build/libs/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
Closes #9

## Notas
- Agente OTel v2.9.0 montado como volumen read-only en los 4 servicios
- JAVA_TOOL_OPTIONS inyecta el agente sin modificar codigo Kotlin
- Kafka agregado al docker-compose en modo KRaft sin Zookeeper
- Dockerfiles multi-stage para los 4 servicios Kotlin
- Script download-otel-agent.sh para descargar el jar antes del primer docker compose up
- infra/otel-agent/ en .gitignore — el jar no va al repo